### PR TITLE
Support context path from index file when pushing

### DIFF
--- a/cmd/helmpush/main.go
+++ b/cmd/helmpush/main.go
@@ -232,7 +232,7 @@ func (p *pushCmd) push() error {
 		if err != nil {
 			return err
 		}
-		client.Option(cm.ContextPath(index.ContextPath))
+		client.Option(cm.ContextPath(index.ServerInfo.ContextPath))
 	}
 
 	tmp, err := ioutil.TempDir("", "helm-push-")

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -1,0 +1,48 @@
+package helm
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/helm/pkg/repo"
+)
+
+type (
+	// Index represents the index file in a chart repository
+	Index struct {
+		*repo.IndexFile
+		ContextPath string `json:"contextPath"`
+	}
+
+	// IndexDownloader is a function to download the index
+	IndexDownloader func() ([]byte, error)
+)
+
+// GetIndexByRepo returns index by repository
+func GetIndexByRepo(repo *Repo, downloadIndex IndexDownloader) (*Index, error) {
+	if repo.Cache != "" {
+		return GetIndexByDownloader(func() ([]byte, error) {
+			return ioutil.ReadFile(repo.Cache)
+		})
+	}
+	return GetIndexByDownloader(downloadIndex)
+}
+
+// GetIndexByDownloader takes binary data from IndexDownloader and returns an Index object
+func GetIndexByDownloader(downloadIndex IndexDownloader) (*Index, error) {
+	b, err := downloadIndex()
+	if err != nil {
+		return nil, err
+	}
+	return LoadIndex(b)
+}
+
+// LoadIndex loads an index file
+func LoadIndex(data []byte) (*Index, error) {
+	i := &Index{}
+	if err := yaml.Unmarshal(data, i); err != nil {
+		return i, err
+	}
+	i.SortEntries()
+	return i, nil
+}

--- a/pkg/helm/index.go
+++ b/pkg/helm/index.go
@@ -11,7 +11,7 @@ type (
 	// Index represents the index file in a chart repository
 	Index struct {
 		*repo.IndexFile
-		ContextPath string `json:"contextPath"`
+		ServerInfo ServerInfo `json:"serverInfo"`
 	}
 
 	// IndexDownloader is a function to download the index

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -1,0 +1,25 @@
+package helm
+
+import (
+	"testing"
+)
+
+func TestLoadIndex(t *testing.T) {
+	// No context path
+	index, err := LoadIndex([]byte("apiVersion: v1\nentries: {}\ngenerated: \"2018-08-08T08:21:33Z\"\n"))
+	if err != nil {
+		t.Error("unexpected error loading index", err)
+	}
+	if index.ContextPath != "" {
+		t.Errorf("expexted empty context path, instead got %s", index.ContextPath)
+	}
+
+	// Has context path
+	index, err = LoadIndex([]byte("apiVersion: v1\ncontextPath: /helm/v1\nentries: {}\ngenerated: \"2018-08-08T08:21:33Z\"\n"))
+	if err != nil {
+		t.Error("unexpected error loading index", err)
+	}
+	if index.ContextPath != "/helm/v1" {
+		t.Errorf("expexted context path to be /helm/v1, instead got %s", index.ContextPath)
+	}
+}

--- a/pkg/helm/index_test.go
+++ b/pkg/helm/index_test.go
@@ -10,16 +10,16 @@ func TestLoadIndex(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error loading index", err)
 	}
-	if index.ContextPath != "" {
-		t.Errorf("expexted empty context path, instead got %s", index.ContextPath)
+	if index.ServerInfo.ContextPath != "" {
+		t.Errorf("expexted empty context path, instead got %s", index.ServerInfo.ContextPath)
 	}
 
 	// Has context path
-	index, err = LoadIndex([]byte("apiVersion: v1\ncontextPath: /helm/v1\nentries: {}\ngenerated: \"2018-08-08T08:21:33Z\"\n"))
+	index, err = LoadIndex([]byte("apiVersion: v1\nserverInfo:\n  contextPath: /helm/v1\nentries: {}\ngenerated: \"2018-08-08T08:21:33Z\"\n"))
 	if err != nil {
 		t.Error("unexpected error loading index", err)
 	}
-	if index.ContextPath != "/helm/v1" {
-		t.Errorf("expexted context path to be /helm/v1, instead got %s", index.ContextPath)
+	if index.ServerInfo.ContextPath != "/helm/v1" {
+		t.Errorf("expexted context path to be /helm/v1, instead got %s", index.ServerInfo.ContextPath)
 	}
 }

--- a/pkg/helm/serverinfo.go
+++ b/pkg/helm/serverinfo.go
@@ -1,0 +1,8 @@
+package helm
+
+type (
+	// ServerInfo describes the server information
+	ServerInfo struct {
+		ContextPath string `json:"contextPath"`
+	}
+)


### PR DESCRIPTION
When pushing charts to the remote server, the plugin automatically sets the context path from the cached repo index file. If pushing to a URL not a repo or the cache does not exist, the plugin tries to get the index file directly from the server.

Here is an example server generated index file with context path located at `http://example.com/some/path/index.yaml` with repo url `http://example.com/some/path`.
```yaml
apiVersion: v1
serverInfo:
  contextPath: /some/path
entries: {}
generated: "2018-08-08T08:00:00Z"
```
With this index file, the plugin will send requests to `http://example.com/some/path/api/charts` for pushing charts instead of `http://example.com/api/some/path/charts`.