### PR TITLE
fix local pkg repackage error

### DIFF
--- a/cmd/helmpush/main.go
+++ b/cmd/helmpush/main.go
@@ -316,6 +316,9 @@ func (p *pushCmd) push() error {
 	if err != nil {
 		return err
 	}
+	if strings.HasSuffix(p.chartName, ".tgz") {
+		chartPackagePath = p.chartName
+	}
 
 	fmt.Printf("Pushing %s to %s...\n", filepath.Base(chartPackagePath), p.repoName)
 	resp, err := client.UploadChartPackage(chartPackagePath, p.forceUpload)


### PR DESCRIPTION
Use helm push to upload the local PKG to Chartmuseum, which is lost Value.yaml, and sort user-defined order.

**How to Reproduce**:
1. Use `helm package` to pkg it
```shell
helm package demo
``` 
```
Successfully packaged chart and saved it to: /tmp/demo-0.1.0.tgz
```
2. Upload it to Chartmuseum
```shell
helm push /tmp/demo-0.1.0.tgz <repo_name>
```
```
Pushing demo-0.1.0.tgz to <repo_name>..
Done
```
3. Pull it to local
```shell
helm pull <repo_name>/demo
```

Compare when the operation is completed Value.yaml You can find out:

Before Uploaded:
```yaml
# Default values for demo.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.
global:
  env:
    testenv: "testenv"


replicaCount: 1

image:
  repository: nginx
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart version.
  tag: ""

imagePullSecrets: []
nameOverride: ""
fullnameOverride: ""

serviceAccount:
  # Specifies whether a service account should be created
  create: true
  # Annotations to add to the service account
  annotations: {}
  # The name of the service account to use.
  # If not set and create is true, a name is generated using the fullname template
  name: ""

podAnnotations: {}

podSecurityContext: {}
  # fsGroup: 2000

securityContext: {}
  # capabilities:
  #   drop:
  #   - ALL
  # readOnlyRootFilesystem: true
  # runAsNonRoot: true
  # runAsUser: 1000

service:
  type: ClusterIP
  port: 80

ingress:
  enabled: false
  annotations: {}
    # kubernetes.io/ingress.class: nginx
    # kubernetes.io/tls-acme: "true"
  hosts:
    - host: chart-example.local
      paths: []
  tls: []
  #  - secretName: chart-example-tls
  #    hosts:
  #      - chart-example.local

resources: {}
  # We usually recommend not to specify default resources and to leave this as a conscious
  # choice for the user. This also increases chances charts run on environments with little
  # resources, such as Minikube. If you do want to specify resources, uncomment the following
  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
  # limits:
  #   cpu: 100m
  #   memory: 128Mi
  # requests:
  #   cpu: 100m
  #   memory: 128Mi

autoscaling:
  enabled: false
  minReplicas: 1
  maxReplicas: 100
  targetCPUUtilizationPercentage: 80
  # targetMemoryUtilizationPercentage: 80

nodeSelector: {}

tolerations: []

affinity: {}
```
After Uploaded:
```yaml
affinity: {}
autoscaling:
  enabled: false
  maxReplicas: 100
  minReplicas: 1
  targetCPUUtilizationPercentage: 80
fullnameOverride: ""
global:
  env:
    testenv: testenv
image:
  pullPolicy: IfNotPresent
  repository: nginx
  tag: ""
imagePullSecrets: []
ingress:
  annotations: {}
  enabled: false
  hosts:
  - host: chart-example.local
    paths: []
  tls: []
nameOverride: ""
nodeSelector: {}
podAnnotations: {}
podSecurityContext: {}
replicaCount: 1
resources: {}
securityContext: {}
service:
  port: 80
  type: ClusterIP
serviceAccount:
  annotations: {}
  create: true
  name: ""
tolerations: []
```

