### PR TITLE
Unset accessToken if repo credentials are provided

### DIFF
--- a/cmd/helmpush/main.go
+++ b/cmd/helmpush/main.go
@@ -273,7 +273,7 @@ func (p *pushCmd) push() error {
 	}
 
 	// unset accessToken if repo credentials are provided
-	if repo.Config.Username != "" && repo.Config.Password != "" {
+	if username != "" && password != "" {
 		p.accessToken = ""
 	}
 

--- a/cmd/helmpush/main.go
+++ b/cmd/helmpush/main.go
@@ -272,6 +272,11 @@ func (p *pushCmd) push() error {
 		password = p.password
 	}
 
+	// unset accessToken if repo credentials are provided
+	if repo.Config.Username != "" && repo.Config.Password != "" {
+		p.accessToken = ""
+	}
+
 	// in case the repo is stored with cm:// protocol, remove it
 	var url string
 	if p.useHTTP {


### PR DESCRIPTION
As per #81 `~/.cfconfig` options overwrite any repo credentials which is not desired when credentials are provided for private repos other than Codefresh Managed Repos. This PR fixes this behavior.

The change has been tested with both a Codefresh managed repo, and a private repo.