### PR TITLE
fix: rename push cmd to work with new helm version

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,4 @@
-name: "push"
+name: "legacy-push"
 version: "0.9.0"
 usage: "Please see https://github.com/chartmuseum/helm-push for usage"
 description: "Push chart package to ChartMuseum"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,4 @@
-name: "legacy-push"
+name: "cm-push"
 version: "0.9.0"
 usage: "Please see https://github.com/chartmuseum/helm-push for usage"
 description: "Push chart package to ChartMuseum"


### PR DESCRIPTION
As helm 3.7.x turn `helm push` a top level command, we can't use it more to this plugin.

To continue this plugin working, we just need to rename the command that will be mapped by helm.
