### PR TITLE
Remove .git in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helm plugin to push chart package to [ChartMuseum](https://github.com/helm/chart
 Based on the version in `plugin.yaml`, release binary will be downloaded from GitHub:
 
 ```
-$ helm plugin install https://github.com/chartmuseum/helm-push.git
+$ helm plugin install https://github.com/chartmuseum/helm-push
 Downloading and installing helm-push v0.10.1 ...
 https://github.com/chartmuseum/helm-push/releases/download/v0.10.1/helm-push_0.10.1_darwin_amd64.tar.gz
 Installed plugin: cm-push


### PR DESCRIPTION
Fix for #123, remove .git in README.md at the end of install command.

```
helm version
version.BuildInfo{Version:"v3.7.2", GitCommit:"663a896f4a815053445eec4153677ddc24a0a361", GitTreeState:"clean", GoVersion:"go1.17.3"}
```