### PR TITLE
fix(push):  no cached repository found

### DIFF
--- a/cmd/helm-cm-push/main.go
+++ b/cmd/helm-cm-push/main.go
@@ -243,11 +243,13 @@ func (p *pushCmd) push() error {
 				}
 			} else {
 				downloadManager := &downloader.Manager{
-					Out:       p.out,
-					ChartPath: chartPath,
-					Keyring:   p.keyring,
-					Getters:   getter.All(settings),
-					Debug:     v2settings.Debug,
+					Out:              p.out,
+					ChartPath:        chartPath,
+					Keyring:          p.keyring,
+					Getters:          getter.All(settings),
+					Debug:            settings.Debug,
+					RepositoryConfig: settings.RepositoryConfig,
+					RepositoryCache:  settings.RepositoryCache,
 				}
 				if err := downloadManager.Update(); err != nil {
 					return err

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "cm-push"
-version: "0.10.3"
+version: "0.10.4"
 usage: "Please see https://github.com/chartmuseum/helm-push for usage"
 description: "Push chart package to ChartMuseum"
 command: "$HELM_PLUGIN_DIR/bin/helm-cm-push"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -38,11 +38,11 @@ esac
 
 
 if [ "$(uname)" = "Darwin" ]; then
-    url="https://github.com/chartmuseum/helm-push/releases/download/v${version}/helm-push_${version}_darwin_${arch}.tar.gz"
+    url="https://github.com/cnfatal/helm-push/releases/download/v${version}/helm-push_${version}_darwin_${arch}.tar.gz"
 elif [ "$(uname)" = "Linux" ] ; then
-    url="https://github.com/chartmuseum/helm-push/releases/download/v${version}/helm-push_${version}_linux_${arch}.tar.gz"
+    url="https://github.com/cnfatal/helm-push/releases/download/v${version}/helm-push_${version}_linux_${arch}.tar.gz"
 else
-    url="https://github.com/chartmuseum/helm-push/releases/download/v${version}/helm-push_${version}_windows_${arch}.tar.gz"
+    url="https://github.com/cnfatal/helm-push/releases/download/v${version}/helm-push_${version}_windows_${arch}.tar.gz"
 fi
 
 echo $url


### PR DESCRIPTION
Fixed the push with update-dependencies error:

```bash
$ helm cm-push -d -f my-chart <some-chartmuseum>
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Error: no cached repository for helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59 found. (try 'helm repo update'): open helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59-index.yaml: no such file or directory
Usage:
  helm cm-push [flags]
...
```