### PR TITLE
Fix no cached repository found when  push with dependencies update 

### DIFF
--- a/cmd/helm-cm-push/main.go
+++ b/cmd/helm-cm-push/main.go
@@ -243,11 +243,13 @@ func (p *pushCmd) push() error {
 				}
 			} else {
 				downloadManager := &downloader.Manager{
-					Out:       p.out,
-					ChartPath: chartPath,
-					Keyring:   p.keyring,
-					Getters:   getter.All(settings),
-					Debug:     v2settings.Debug,
+					Out:              p.out,
+					ChartPath:        chartPath,
+					Keyring:          p.keyring,
+					Getters:          getter.All(settings),
+					Debug:            settings.Debug,
+					RepositoryConfig: settings.RepositoryConfig,
+					RepositoryCache:  settings.RepositoryCache,
 				}
 				if err := downloadManager.Update(); err != nil {
 					return err


### PR DESCRIPTION
Fixed the push with update-dependencies error:

```bash
$ helm cm-push -d -f my-chart <some-chartmuseum>
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
Error: no cached repository for helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59 found. (try 'helm repo update'): open helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59-index.yaml: no such file or directory
Usage:
  helm cm-push [flags]
...
```