### PR TITLE
Update go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chartmuseum/helm-push
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Opening this PR to resolve some vulnerabilities found in go 1.20. Here is the issue that I opened: https://github.com/chartmuseum/helm-push/issues/199

I have not tested this change.