### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.11.1
+
+### Fixes
+- **Fix plugin manifest compatibility for Helm v3 and v4** — ship `plugin.yaml` in Helm 3 (legacy) format so both versions can parse it; the install hook swaps to the Helm 4 manifest when needed (#234, #235, #237)
+
+### Tests
+- Add plugin manifest compatibility tests that validate YAML against both Helm v3 and v4 parsing logic, preventing future regressions
+
 ## v0.11.0
 
 ### Breaking Changes

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "cm-push"
-version: "0.11.0"
+version: "0.11.1"
 usage: "Please see https://github.com/chartmuseum/helm-push for usage"
 description: "Push chart package to ChartMuseum"
 command: "$HELM_PLUGIN_DIR/bin/helm-cm-push"

--- a/testdata/plugin-helm3.yaml
+++ b/testdata/plugin-helm3.yaml
@@ -1,5 +1,5 @@
 name: "cm-push"
-version: "0.11.0"
+version: "0.11.1"
 usage: "Please see https://github.com/chartmuseum/helm-push for usage"
 description: "Push chart package to ChartMuseum"
 command: "$HELM_PLUGIN_DIR/bin/helm-cm-push"

--- a/testdata/plugin-helm4.yaml
+++ b/testdata/plugin-helm4.yaml
@@ -1,5 +1,5 @@
 name: "cm-push"
-version: "0.11.0"
+version: "0.11.1"
 apiVersion: v1
 type: cli/v1
 runtime: subprocess


### PR DESCRIPTION
## Summary
- Bump version to v0.11.1 in `plugin.yaml`, `testdata/plugin-helm3.yaml`, `testdata/plugin-helm4.yaml`
- Add `CHANGELOG.md` entry for v0.11.1

## Release Highlights (v0.11.1)

### Fixes
- **Fix plugin manifest compatibility for Helm v3 and v4** — the v0.11.0 `plugin.yaml` mixed Helm 3/4 fields, causing unmarshal errors on both versions (#234, #235, #237)

### Tests
- Plugin manifest compatibility tests added to prevent regressions

## Post-merge
After this PR merges, tag and push to trigger the automated release:
```bash
git tag -a v0.11.1 -m "Release v0.11.1"
git push origin v0.11.1
```